### PR TITLE
Mac TUN Persist bug fixed

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "OpenVPNAdapter",
     platforms: [
-        .iOS("9.0"),
+        .iOS("12.0"),
         .macOS("10.11"),
     ],
     products: [

--- a/Scripts/pull_dependencies.sh
+++ b/Scripts/pull_dependencies.sh
@@ -12,3 +12,6 @@ source Sources/OpenVPN3/deps/lib-versions
 git subtree pull --prefix Sources/ASIO git@github.com:chriskohlhoff/asio.git ${ASIO_VERSION} --squash -m "update ASIO"
 git subtree pull --prefix Sources/LZ4 git@github.com:lz4/lz4.git ${LZ4_VERSION/lz4-/v} --squash -m "update LZ4"
 git subtree pull --prefix Sources/mbedTLS git@github.com:ARMmbed/mbedtls.git ${MBEDTLS_VERSION} --squash -m "update mbedTLS"
+
+echo 'All dependencies updated.'
+echo 'WARNING: Manual actions required. Follow the instructions in updating-readme.md'

--- a/Scripts/updating-readme.md
+++ b/Scripts/updating-readme.md
@@ -1,0 +1,43 @@
+# Updating OpenVPN3 or dependencies
+
+## Run pull_dependencies script
+
+1. Change `OPENVPN3_VERSION` in `pull_dependencies.sh` to desired commit/tag
+2. From the root of repository, run `$ ./Scripts/pull_dependencies.sh`
+3. Script will pull both OpenVPN3 code and its subdependencies via Git Subtree. Versions of subdependencies are specified inside OpenVPN3 library and cannot be changed.
+
+## Apply fixes to OpenVPN3 code manually
+
+Manual code editing is required until better solution is found.
+
+### Set proper TUN Builder options for mac (Fixes tun persist bug, when reconnect to server after reachability change fails):
+
+- Open `Sources/OpenVPN3/openvpn/client/cliopt.hpp`
+- Find the following region:
+
+```swift
+#if defined(OPENVPN_PLATFORM_IPHONE)
+                tunconf->retain_sd = true;
+                tunconf->tun_prefix = true;
+                if (config.tun_persist)
+                    tunconf->tun_prop.remote_bypass = true;
+```
+
+- Replace it with:
+
+```swift
+#if (defined(OPENVPN_PLATFORM_IPHONE) || defined(OPENVPN_PLATFORM_MAC))
+                tunconf->retain_sd = true;
+                tunconf->tun_prefix = true;
+                if (config.tun_persist)
+                    tunconf->tun_prop.remote_bypass = true;
+```
+
+- Comment out separate region with tun setting for mac:
+
+```swift
+// #if defined(OPENVPN_PLATFORM_MAC)
+//                tunconf->tun_prefix = true;
+```
+
+This will unify TUN Builder configuration process for iOS and Mac.

--- a/Scripts/updating-readme.md
+++ b/Scripts/updating-readme.md
@@ -15,7 +15,7 @@ Manual code editing is required until better solution is found.
 - Open `Sources/OpenVPN3/openvpn/client/cliopt.hpp`
 - Find the following region:
 
-```swift
+```cpp
 #if defined(OPENVPN_PLATFORM_IPHONE)
                 tunconf->retain_sd = true;
                 tunconf->tun_prefix = true;
@@ -25,7 +25,7 @@ Manual code editing is required until better solution is found.
 
 - Replace it with:
 
-```swift
+```cpp
 #if (defined(OPENVPN_PLATFORM_IPHONE) || defined(OPENVPN_PLATFORM_MAC))
                 tunconf->retain_sd = true;
                 tunconf->tun_prefix = true;
@@ -35,7 +35,7 @@ Manual code editing is required until better solution is found.
 
 - Comment out separate region with tun setting for mac:
 
-```swift
+```cpp
 // #if defined(OPENVPN_PLATFORM_MAC)
 //                tunconf->tun_prefix = true;
 ```

--- a/Sources/OpenVPN3/openvpn/client/cliopt.hpp
+++ b/Sources/OpenVPN3/openvpn/client/cliopt.hpp
@@ -392,7 +392,7 @@ class ClientOptions : public RC<thread_unsafe_refcount>
                 tunconf->stats = cli_stats;
                 tunconf->tun_prop.remote_list = remote_list;
                 tun_factory = tunconf;
-#if defined(OPENVPN_PLATFORM_IPHONE)
+#if (defined(OPENVPN_PLATFORM_IPHONE) || defined(OPENVPN_PLATFORM_MAC))
                 tunconf->retain_sd = true;
                 tunconf->tun_prefix = true;
                 if (config.tun_persist)
@@ -410,9 +410,9 @@ class ClientOptions : public RC<thread_unsafe_refcount>
                     tunconf->eer_factory.reset(nullptr);
                 }
 #endif
-#if defined(OPENVPN_PLATFORM_MAC)
-                tunconf->tun_prefix = true;
-#endif
+//#if defined(OPENVPN_PLATFORM_MAC)
+//                tunconf->tun_prefix = true;
+//#endif
                 if (config.tun_persist)
                     tunconf->tun_persist.reset(new TunBuilderClient::TunPersist(true, tunconf->retain_sd ? TunWrapObjRetain::RETAIN : TunWrapObjRetain::NO_RETAIN, config.builder));
                 tun_factory = tunconf;

--- a/Sources/OpenVPNAdapter/library/OpenVPNPacketFlowBridge.mm
+++ b/Sources/OpenVPNAdapter/library/OpenVPNPacketFlowBridge.mm
@@ -15,6 +15,8 @@
 #import "OpenVPNPacket.h"
 #import "OpenVPNAdapterPacketFlow.h"
 
+#define STATIC_BUFFER_SIZE 64*1024 // Buffer used for reading & writing from sockets
+
 @implementation OpenVPNPacketFlowBridge
 
 #pragma mark - Sockets Configuration
@@ -52,7 +54,7 @@ static void SocketCallback(NSData *data, OpenVPNPacketFlowBridge *obj) {
     _source = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, _packetFlowSocket, 0, DISPATCH_QUEUE_SERIAL);
     dispatch_source_set_event_handler(_source, ^{
         unsigned long bytesAvail = dispatch_source_get_data(_source);
-        static char buffer[1024*500];    // 500 KB buffer
+        static char buffer[STATIC_BUFFER_SIZE];
         unsigned long actual = read(_packetFlowSocket, buffer, sizeof(buffer));
         NSData* someData = [NSData dataWithBytes:(const void *)buffer length:sizeof(unsigned char)*actual];
         SocketCallback(someData, self);
@@ -158,7 +160,7 @@ static void SocketCallback(NSData *data, OpenVPNPacketFlowBridge *obj) {
         NSNumber *protocolFamily = protocols[idx];
         OpenVPNPacket *packet = [[OpenVPNPacket alloc] initWithPacketFlowData:data protocolFamily:protocolFamily];
 
-        char buffer[1024*500];
+        static char buffer[STATIC_BUFFER_SIZE];
         [packet.vpnData getBytes:buffer length:packet.vpnData.length];
         write(socket, buffer, packet.vpnData.length);
     }];


### PR DESCRIPTION
Встроенный в OpenVPN3 кроссплатформенный TunBuilder для мачка почему-то при конфигурации не задает флаг retain_sd (stream descriptor), хотя для ios например задает. Сделал чтоб конфигурация для мака и для ios была одинаковой. Это исправляет баг с переподключением на маке - и для tcp и для udp.

Единственный момент: баг не в адаптере, а в самой openvpn3. По хорошему, надо сделать форк и исправить там - я так попробовал сделать, но потом этот форк надо подключить к скрипту pull_dependencies. Вот с этим возникли трудности, тк там используется Subtree и просто сменить адрес в скрипте недостаточно - надо удалять и добавлять новый subtree. Я сходу это не вывез и решил на первое время схалявить (к тому же нужно подтверждение от тестеров что фикс нормально работает) - просто поменял в коде openvpn3 что надо, а в скрипте апдейта добавил вывод предупреждения, что после апдейта надо вручную поменять код. Инструкции что именно поменять даны в updating-readme.md

UPD: Поднял минимальную версию ios до 12 (для поддержки c++17)
UPD2: [Подправил](https://github.com/ntoichkina/OpenVPNAdapter/pull/6/commits/4e9455b16cbca05193b4b31667541c7afc7ab2a9) буфферы чтения/записи в сокеты - буффер для записи сделал статическим (видимо по ошибке его таким не сделали изначально), и уменьшил их с 500кб до 64. Учитывая что MTU у нас около 1,5кб такой большой буффер в принципе не обязателен, но раз он все равно статический, то не важно.